### PR TITLE
feat: add some tests for status endpoint and refactor the test harness again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,6 @@ jobs:
       postgres:
         image: postgres:15.18-alpine3.24
         env:
-          SQLX_OFFLINE: true
           POSTGRES_USER: deploydodo
           POSTGRES_PASSWORD: deploydodo
           POSTGRES_DB: deploydodo

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   cargo-clippy:
-    name: cargo fmt
+    name: cargo clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -69,10 +69,11 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Check formatting
+      - name: Run Clippy
         run: cargo clippy
 
   build:
+    needs: [cargo-clippy, cargo-fix, cargo-fmt]
     name: cargo make build-debug
     runs-on: ubuntu-latest
     steps:
@@ -108,10 +109,10 @@ jobs:
       - name: Build
         run: cargo make build-debug
   test-backend:
+    needs: [cargo-clippy, cargo-fix, cargo-fmt]
     name: Test backend
     runs-on: ubuntu-latest
     env:
-      SQLX_OFFLINE: true
       DATABASE_URL: postgres://deploydodo:deploydodo@localhost:5432/deploydodo
       LOCAL_SSH_HOSTNAME: localhost
       LOCAL_SSH_PORT: 22
@@ -151,4 +152,6 @@ jobs:
         run: ./configure_rsa.sh
 
       - name: Test
+        env:
+          SQLX_OFFLINE: true
         run: cargo test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,7 +150,7 @@ jobs:
             target/
           key: cargo-debug-${{ runner.os }}
 
-      - name: Install cargo-make
+      - name: Install Binaries
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-make,sqlx-cli

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,6 +121,7 @@ jobs:
       postgres:
         image: postgres:15.18-alpine3.24
         env:
+          SQLX_OFFLINE: true
           POSTGRES_USER: deploydodo
           POSTGRES_PASSWORD: deploydodo
           POSTGRES_DB: deploydodo
@@ -148,6 +149,13 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: cargo-debug-${{ runner.os }}
+
+      - name: Run DB Migrations
+        run: cargo make migrate
+
+      - name: Check SQL query
+        run: cargo make check-query
+
       - name: Generate RSA
         run: ./configure_rsa.sh
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,6 +150,9 @@ jobs:
             target/
           key: cargo-debug-${{ runner.os }}
 
+      - name: Install cargo-make
+        uses: taiki-e/install-action@cargo-make
+
       - name: Run DB Migrations
         run: cargo make migrate
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,7 +151,9 @@ jobs:
           key: cargo-debug-${{ runner.os }}
 
       - name: Install cargo-make
-        uses: taiki-e/install-action@cargo-make
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-make,sqlx-cli
 
       - name: Run DB Migrations
         run: cargo make migrate

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -91,7 +91,7 @@ args = ["compose", "-f", "dev.docker-compose.yaml", "up", "-d"]
 
 [tasks.dev]
 description = "Run backend and frontend concurrently"
-dependencies = ["deploy-dev-db", "check-query"]
+dependencies = ["deploy-dev-db"]
 run_task = { name = ["backend", "frontend"], parallel = true }
 
 [tasks.build]

--- a/backend/src/routes/create_admin.rs
+++ b/backend/src/routes/create_admin.rs
@@ -98,10 +98,9 @@ mod tests {
 
     #[sqlx::test]
     fn create_admin_fails_if_name_is_missing(db: Pool<Postgres>) {
-        let app = App::register_create_admin(db).await;
+        let app = App::register_route(db, post(create_admin)).await;
 
-        app.server
-            .post("/api/setup/admin")
+        app.post()
             .json(&json!({}))
             .await
             .assert_status_unprocessable_entity()
@@ -110,10 +109,9 @@ mod tests {
 
     #[sqlx::test]
     fn create_admin_fails_if_email_is_missing(db: Pool<Postgres>) {
-        let app = App::register_create_admin(db).await;
+        let app = App::register_route(db, post(create_admin)).await;
 
-        app.server
-            .post("/api/setup/admin")
+        app.post()
             .json(&json!({"name": "Test user"}))
             .await
             .assert_status_unprocessable_entity()
@@ -122,10 +120,9 @@ mod tests {
 
     #[sqlx::test]
     fn create_admin_fails_if_password_is_missing(db: Pool<Postgres>) {
-        let app = App::register_create_admin(db).await;
+        let app = App::register_route(db, post(create_admin)).await;
 
-        app.server
-            .post("/api/setup/admin")
+        app.post()
             .json(&json!({"name": "Test user", "email": "test@user.com"}))
             .await
             .assert_status_unprocessable_entity()
@@ -134,10 +131,9 @@ mod tests {
 
     #[sqlx::test]
     fn create_admin_fails_if_name_is_blank(db: Pool<Postgres>) {
-        let app = App::register_create_admin(db).await;
+        let app = App::register_route(db, post(create_admin)).await;
 
-        app.server
-            .post("/api/setup/admin")
+        app.post()
             .json(&json!({"name": "", "email": "", "password": ""}))
             .await
             .assert_status_bad_request()
@@ -148,10 +144,9 @@ mod tests {
 
     #[sqlx::test]
     fn create_admin_fails_if_email_is_blank(db: Pool<Postgres>) {
-        let app = App::register_create_admin(db).await;
+        let app = App::register_route(db, post(create_admin)).await;
 
-        app.server
-            .post("/api/setup/admin")
+        app.post()
             .json(&json!({"name": "Test user", "email": "", "password": ""}))
             .await
             .assert_status_bad_request()
@@ -162,21 +157,14 @@ mod tests {
 
     #[sqlx::test]
     fn create_admin_fails_if_password_is_blank(db: Pool<Postgres>) {
-        let app = App::register_create_admin(db).await;
+        let app = App::register_route(db, post(create_admin)).await;
 
-        app.server
-            .post("/api/setup/admin")
+        app.post()
             .json(&json!({"name": "Test user", "email": "test@user.com", "password": ""}))
             .await
             .assert_status_bad_request()
             .assert_json_contains(&json!({
                 "message": "Password must be at least 8 characters"
             }));
-    }
-
-    impl App {
-        async fn register_create_admin(db: Pool<Postgres>) -> Self {
-            App::register_route(db, "/api/setup/admin", post(create_admin)).await
-        }
     }
 }

--- a/backend/src/routes/status.rs
+++ b/backend/src/routes/status.rs
@@ -64,3 +64,44 @@ pub async fn status(State(deps): State<Dependencies>) -> AppResult<Json<StatusRe
         is_onboarding_complete: is_admin_onboarded && is_server_setup && is_project_setup,
     }))
 }
+
+#[cfg(test)]
+mod tests {
+    use axum::routing::get;
+    use serde_json::json;
+    use sqlx::{Pool, Postgres};
+
+    use super::status;
+    use crate::{services::types::VariableKey, test::App};
+
+    #[sqlx::test]
+    fn status_returns_false_for_all_variables(db: Pool<Postgres>) {
+        let app = App::register_route(db, get(status)).await;
+
+        app.get().await.assert_status_ok().assert_json(&json!({
+            "isAdminOnboarded": false,
+            "isServerSetup": false,
+            "isProjectSetup": false,
+            "isOnboardingComplete": false,
+            "isLocalServerSetup": false,
+        }));
+    }
+
+    #[sqlx::test]
+    fn status_returns_true_for_set_var(db: Pool<Postgres>) {
+        let app = App::register_route(db, get(status)).await;
+
+        let _ = app
+            .deps
+            .variables_service
+            .set_value(VariableKey::IsAdminOnboarded, true)
+            .await;
+
+        app.get()
+            .await
+            .assert_status_ok()
+            .assert_json_contains(&json!({
+                "isAdminOnboarded": true,
+            }));
+    }
+}

--- a/backend/src/services/server_service.rs
+++ b/backend/src/services/server_service.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, u16};
+use std::sync::Arc;
 
 use chrono::Utc;
 use serde::{Deserialize, Serialize};

--- a/backend/src/test/mod.rs
+++ b/backend/src/test/mod.rs
@@ -3,15 +3,17 @@ use std::sync::Arc;
 use crate::{dependencies::Dependencies, env, middleware};
 
 use axum::{routing::MethodRouter, Router};
-use axum_test::TestServer;
+use axum_test::{TestRequest, TestServer};
 use sqlx::{Pool, Postgres};
 use std::sync::Once;
 
 static INIT: Once = Once::new();
 
+static TEST_ENDPOINT: &str = "/test-api";
+
 pub struct App {
-    pub db: Arc<Pool<Postgres>>,
-    pub server: TestServer,
+    pub deps: Dependencies,
+    server: TestServer,
 }
 
 fn init_test_env() {
@@ -20,9 +22,24 @@ fn init_test_env() {
 }
 
 impl App {
+    pub fn get(&self) -> TestRequest {
+        self.server.get(TEST_ENDPOINT)
+    }
+
+    pub fn post(&self) -> TestRequest {
+        self.server.post(TEST_ENDPOINT)
+    }
+
+    pub fn delete(&self) -> TestRequest {
+        self.server.delete(TEST_ENDPOINT)
+    }
+
+    pub fn patch(&self) -> TestRequest {
+        self.server.patch(TEST_ENDPOINT)
+    }
+
     pub async fn register_route(
         db: Pool<Postgres>,
-        path: &str,
         method_router: MethodRouter<Dependencies>,
     ) -> Self {
         INIT.call_once(init_test_env);
@@ -31,12 +48,12 @@ impl App {
             Dependencies::init_with_db(db.clone()).expect("failed to initialize dependencies");
 
         let router = Router::new()
-            .route(path, method_router)
-            .with_state(deps)
+            .route(TEST_ENDPOINT, method_router)
+            .with_state(deps.clone())
             .layer(axum::middleware::from_fn(middleware::bearer_auth));
 
         let server = TestServer::new(router);
 
-        App { db: db, server }
+        App { deps, server }
     }
 }

--- a/dodosh/src/terminal/docker.rs
+++ b/dodosh/src/terminal/docker.rs
@@ -13,11 +13,14 @@ use crate::{
     DockerTunnel, ShellError, SshAuth, SshSession, SshTimeout,
 };
 
+type DockerInput = Pin<Box<dyn AsyncWrite + Send>>;
+type DockerOutput = Pin<Box<dyn Stream<Item = Result<LogOutput, bollard::errors::Error>> + Send>>;
+
 pub struct DockerChannel {
     docker: bollard::Docker,
     exec_id: String,
-    input: Mutex<Pin<Box<dyn AsyncWrite + Send>>>,
-    output: Mutex<Pin<Box<dyn Stream<Item = Result<LogOutput, bollard::errors::Error>> + Send>>>,
+    input: Mutex<DockerInput>,
+    output: Mutex<DockerOutput>,
     _tunnel: Option<DockerTunnel>,
 }
 


### PR DESCRIPTION
This description is AI Generated

## Summary

Refactors the backend test harness to be terser and endpoint-agnostic, adds
integration tests for the `/api/status` endpoint, and cleans up the CI pipeline
and the local dev-loop task.

## Test harness (`backend/src/test/mod.rs`)

- `App::register_route` no longer takes a `path` argument — every test mounts its
  handler at a single fixed `TEST_ENDPOINT` (`/test-api`), so tests exercise a
  handler in isolation without restating its production route.
- Added `App::get()/post()/delete()/patch()` helpers that return a `TestRequest`
  pre-pointed at `TEST_ENDPOINT`, replacing the verbose
  `app.server.post("/api/…")` calls at each call site.
- `App` now exposes `deps: Dependencies` (so tests can drive services directly,
  e.g. seed variables) and makes `server` private.

## Status endpoint tests (`backend/src/routes/status.rs`)

- `status_returns_false_for_all_variables` — on an empty DB, every flag
  (including `isOnboardingComplete`) serializes as `false`.
- `status_returns_true_for_set_var` — after seeding `IsAdminOnboarded`, the
  endpoint reflects it as `true`.

## create_admin tests (`backend/src/routes/create_admin.rs`)

- Migrated the six existing validation tests to the new harness API and removed
  the now-redundant `register_create_admin` helper.

## CI & dev loop

- `Makefile.toml`: dropped `check-query` from `[tasks.dev]` dependencies, so
  `cargo make dev` no longer gates local server startup on a workspace-wide
  `sqlx prepare --check` (plus its fixed `sleep`) — the check stays in CI where
  it belongs.
- `.github/workflows/ci.yaml`:
  - Fixed a copy-pasted job name (`cargo fmt` → `cargo clippy`) and step name
    (`Check formatting` → `Run Clippy`) on the clippy job.
  - `build` and `test-backend` now `needs: [cargo-clippy, cargo-fix, cargo-fmt]`,
    so the expensive jobs only run after the fast lint/format gates pass.
  - Scoped `SQLX_OFFLINE=true` to the `Test` step only, instead of the whole
    `test-backend` job env.

## Test plan

- [ ] `cargo test -p backend` passes against the CI Postgres service.
- [ ] `cargo make dev` starts backend + frontend without the removed
      `check-query` step.
- [ ] CI: `build`/`test-backend` wait on the lint/fmt jobs; clippy job is
      correctly named.